### PR TITLE
Add parsing of valid pizza orders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-plazza
+/plazza

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,8 @@ BINARY_NAME			=	plazza
 
 MAIN_SRC			=	./src/Main.cpp
 
-SRC					=	./src/CLI.cpp	\
+SRC					=	./src/CLI.cpp							\
+						./src/plazza/reception/Reception.cpp	\
 
 OBJ					=	$(SRC:.cpp=.o)
 

--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,8 @@ VALGRIND_FLAGS		=														\
 CPPLINT_FLAGS		=														\
 	--root=./include														\
 	--repository=. 															\
-	--filter=-legal/copyright,-build/c++17,+build/c++20,-runtime/references,$\
--build/include_subdir,-build/c++11											\
+	--filter=-build/include_subdir,-runtime/references,-build/c++17,-build/$\
+c++11,-legal/copyright,-whitespace/indent_namespace							\
 	--recursive																\
 
 VALGRIND_LOG		=	valgrind.log

--- a/Makefile
+++ b/Makefile
@@ -8,13 +8,14 @@
 .PHONY: all clean fclean re tests_run vg cs linter format
 
 %.o: %.cpp
-	g++ $(CPPFLAGS) -c $< -o $@
+	g++ -c $< -o $@ $(CPPFLAGS)
 
 BINARY_NAME			=	plazza
 
 MAIN_SRC			=	./src/Main.cpp
 
 SRC					=	./src/CLI.cpp							\
+						./src/Utils.cpp							\
 						./src/plazza/reception/Reception.cpp	\
 
 OBJ					=	$(SRC:.cpp=.o)
@@ -25,7 +26,7 @@ MAIN_OBJ			=	$(MAIN_SRC:.cpp=.o)
 SRC_TESTS			=
 
 # Flags -----------------------------------------------------------------------
-INCLUDES			=
+INCLUDES			=	-I./include/ -I./src/
 
 CPPFLAGS			+=	-std=c++20 -Wall -Wextra -Werror $(INCLUDES) 		\
 

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ BINARY_NAME			=	plazza
 
 MAIN_SRC			=	./src/Main.cpp
 
-SRC					=
+SRC					=	./src/CLI.cpp	\
 
 OBJ					=	$(SRC:.cpp=.o)
 

--- a/src/CLI.cpp
+++ b/src/CLI.cpp
@@ -10,6 +10,8 @@
 #include <iostream>
 #include <string>
 
+#include "Utils.hpp"
+
 plazza::CLI::CLI(
     double cookingMultiplier, unsigned int cookNb, unsigned int restockTime)
     : _reception(cookingMultiplier, cookNb, restockTime) {}
@@ -31,8 +33,8 @@ void plazza::CLI::handleInput(const std::string &input) {
         handleExit();
     } else if (input == _helpCommand) {
         handleHelp();
-    } else if (_reception.processOrder(input) == false) {
-        std::cout << "Unknown command: " << input << std::endl;
+    } else if (_reception.processOrder(utils::toLower(input)) == false) {
+        std::cout << "Invalid order: " << input << std::endl;
     }
 }
 

--- a/src/CLI.cpp
+++ b/src/CLI.cpp
@@ -10,9 +10,9 @@
 #include <iostream>
 #include <string>
 
-plazza::CLI::CLI() {}
-
-plazza::CLI::~CLI() {}
+plazza::CLI::CLI(
+    double cookingMultiplier, unsigned int cookNb, unsigned int restockTime)
+    : _reception(cookingMultiplier, cookNb, restockTime) {}
 
 void plazza::CLI::runInterface() {
     while (true) {
@@ -31,8 +31,7 @@ void plazza::CLI::handleInput(const std::string &input) {
         handleExit();
     } else if (input == _helpCommand) {
         handleHelp();
-    } else {
-        // Won't be unknown command but this is where we'll handle pizza orders
+    } else if (_reception.processOrder(input) == false) {
         std::cout << "Unknown command: " << input << std::endl;
     }
 }

--- a/src/CLI.cpp
+++ b/src/CLI.cpp
@@ -35,6 +35,7 @@ void plazza::CLI::handleInput(const std::string &input) {
         handleHelp();
     } else if (_reception.processOrder(utils::toLower(input)) == false) {
         std::cout << "Invalid order: " << input << std::endl;
+        std::cout << "Type 'help' for more information." << std::endl;
     }
 }
 

--- a/src/CLI.cpp
+++ b/src/CLI.cpp
@@ -1,0 +1,60 @@
+/*
+** EPITECH PROJECT, 2025
+** La-Pizza-Delamama
+** File description:
+** CLI
+*/
+
+#include "CLI.hpp"
+
+#include <iostream>
+#include <string>
+
+plazza::CLI::CLI() {}
+
+plazza::CLI::~CLI() {}
+
+void plazza::CLI::runInterface() {
+    while (true) {
+        printPrompt();
+        std::getline(std::cin, _lastInput);
+        handleInput(_lastInput);
+    }
+}
+
+void plazza::CLI::printPrompt() {
+    std::cout << _prompt;
+}
+
+void plazza::CLI::handleInput(const std::string &input) {
+    if (input == _exitCommand) {
+        handleExit();
+    } else if (input == _helpCommand) {
+        handleHelp();
+    } else {
+        // Won't be unknown command but this is where we'll handle pizza orders
+        std::cout << "Unknown command: " << input << std::endl;
+    }
+}
+
+void plazza::CLI::handleExit() {
+    std::cout << "Bye" << std::endl;
+    exit(0);
+}
+
+void plazza::CLI::handleHelp() {
+    std::cout << _helpMessage << std::endl;
+}
+
+std::string plazza::CLI::getLastInput() const {
+    return _lastInput;
+}
+
+// CLIException
+
+plazza::CLI::CLIException::CLIException(const std::string &errmsg)
+    : _errmsg(errmsg) {}
+
+const char *plazza::CLI::CLIException::what() const noexcept {
+    return _errmsg.c_str();
+}

--- a/src/CLI.hpp
+++ b/src/CLI.hpp
@@ -9,11 +9,15 @@
 #define SRC_CLI_HPP_
 #include <string>
 
+#include "plazza/reception/Reception.hpp"
+
 namespace plazza {
 class CLI {
  public:
-    CLI();  // We'll probably want to add the reception arguments here
-    ~CLI();
+    CLI() = delete;
+    CLI(double cookingMultiplier, unsigned int cookNb,
+        unsigned int restockTime);
+    ~CLI() = default;
     void runInterface();
     std::string getLastInput() const;
 
@@ -27,7 +31,7 @@ class CLI {
     };
 
  private:
-    // plazza::Reception _reception;
+    plazza::Reception _reception;
     std::string _lastInput = "";
     std::string _prompt = "plazza> ";
     std::string _exitCommand = "exit";

--- a/src/CLI.hpp
+++ b/src/CLI.hpp
@@ -40,7 +40,9 @@ class CLI {
         "Available commands:\n"
         "\t- exit: Exit the program\n"
         "\t- help: Show this help message\n"
-        "\t- status: Show the status of the kitchen\n";
+        "\t- status: Show the status of the kitchen\n"
+        "\t- <type> <size> <number>[; <type> <size> <number>]: Place an "
+        "order\n";
     void printPrompt();
     void handleInput(const std::string &input);
     void handleExit();

--- a/src/CLI.hpp
+++ b/src/CLI.hpp
@@ -1,0 +1,47 @@
+/*
+** EPITECH PROJECT, 2025
+** La-Pizza-Delamama
+** File description:
+** CLI
+*/
+
+#ifndef SRC_CLI_HPP_
+#define SRC_CLI_HPP_
+#include <string>
+
+namespace plazza {
+class CLI {
+ public:
+    CLI();  // We'll probably want to add the reception arguments here
+    ~CLI();
+    void runInterface();
+    std::string getLastInput() const;
+
+    class CLIException : public std::exception {
+     public:
+        explicit CLIException(const std::string &errmsg);
+        const char *what() const noexcept override;
+
+     private:
+        std::string _errmsg = "No error message specified";
+    };
+
+ private:
+    // plazza::Reception _reception;
+    std::string _lastInput = "";
+    std::string _prompt = "plazza> ";
+    std::string _exitCommand = "exit";
+    std::string _helpCommand = "help";
+    std::string _helpMessage =
+        "Available commands:\n"
+        "\t- exit: Exit the program\n"
+        "\t- help: Show this help message\n"
+        "\t- status: Show the status of the kitchen\n";
+    void printPrompt();
+    void handleInput(const std::string &input);
+    void handleExit();
+    void handleHelp();
+};
+};  // namespace plazza
+
+#endif  // SRC_CLI_HPP_

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -5,7 +5,12 @@
 ** Main
 */
 
+#include "CLI.hpp"
+
 int main(int ac, char **av) {
+    plazza::CLI shell;
+
+    shell.runInterface();
     (void)ac;
     (void)av;
     return 0;

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -8,7 +8,7 @@
 #include "CLI.hpp"
 
 int main(int ac, char **av) {
-    plazza::CLI shell;
+    plazza::CLI shell(1.0, 4, 5);
 
     shell.runInterface();
     (void)ac;

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -1,0 +1,57 @@
+/*
+** EPITECH PROJECT, 2025
+** La-Pizza-Delamama
+** File description:
+** Utils
+*/
+
+#include "Utils.hpp"
+
+#include <string>
+#include <vector>
+
+#include "plazza/Pizza.hpp"
+
+bool utils::isValidPizzaType(const std::string &type) {
+    return plazza::validPizzaTypes.count(type) > 0;
+}
+
+bool utils::isValidPizzaSize(const std::string &size) {
+    return plazza::validPizzaSizes.count(utils::toUpper(size)) > 0;
+}
+
+bool utils::isValidPizzaCount(const std::string &count) {
+    if (count.size() < 2 || count[0] != 'x' || count[1] == '0')
+        return false;
+    for (size_t i = 1; i < count.size(); ++i)
+        if (!std::isdigit(count[i]))
+            return false;
+    return true;
+}
+
+std::vector<std::string> utils::split(
+    const std::string &str, const std::string &delimiter) {
+    std::vector<std::string> tokens;
+    size_t start = 0, end = 0;
+
+    while ((end = str.find(delimiter, start)) != std::string::npos) {
+        tokens.push_back(str.substr(start, end - start));
+        start = end + delimiter.length();
+    }
+    tokens.push_back(str.substr(start));
+    return tokens;
+}
+
+std::string utils::toLower(const std::string &str) {
+    std::string lowerStr = str;
+    for (char &c : lowerStr)
+        c = std::tolower(c);
+    return lowerStr;
+}
+
+std::string utils::toUpper(const std::string &str) {
+    std::string upperStr = str;
+    for (char &c : upperStr)
+        c = std::toupper(c);
+    return upperStr;
+}

--- a/src/Utils.hpp
+++ b/src/Utils.hpp
@@ -1,0 +1,35 @@
+/*
+** EPITECH PROJECT, 2025
+** La-Pizza-Delamama
+** File description:
+** Utils
+*/
+
+#ifndef SRC_UTILS_HPP_
+#define SRC_UTILS_HPP_
+#include <string>
+#include <vector>
+
+namespace utils {
+// Function to split a string by a delimiter
+std::vector<std::string> split(
+    const std::string &str, const std::string &delimiter);
+
+// Function to validate pizza type
+bool isValidPizzaType(const std::string &type);
+
+// Function to validate pizza size
+bool isValidPizzaSize(const std::string &size);
+
+// Function to validate pizza count
+bool isValidPizzaCount(const std::string &count);
+
+// Function to get the lowercase version of a string
+std::string toLower(const std::string &str);
+
+// Function to get the uppercase version of a string
+std::string toUpper(const std::string &str);
+
+}  // namespace utils
+
+#endif  // SRC_UTILS_HPP_

--- a/src/plazza/Pizza.cpp
+++ b/src/plazza/Pizza.cpp
@@ -1,0 +1,13 @@
+/*
+** EPITECH PROJECT, 2025
+** La-Pizza-Delamama
+** File description:
+** Pizza
+*/
+
+#include "Pizza.hpp"
+
+plazza::Pizza::Pizza(PizzaType type, PizzaSize size)
+    : _type(type), _size(size) {}
+
+plazza::Pizza::~Pizza() {}

--- a/src/plazza/Pizza.hpp
+++ b/src/plazza/Pizza.hpp
@@ -1,0 +1,39 @@
+/*
+** EPITECH PROJECT, 2025
+** La-Pizza-Delamama
+** File description:
+** Pizza
+*/
+
+#ifndef SRC_PLAZZA_PIZZA_HPP_
+#define SRC_PLAZZA_PIZZA_HPP_
+
+namespace plazza {
+class Pizza {
+ public:
+    enum PizzaType {
+        Regina = 1,
+        Margarita = 2,
+        Americana = 4,
+        Fantasia = 8
+    };
+
+    enum PizzaSize {
+        S = 1,
+        M = 2,
+        L = 4,
+        XL = 8,
+        XXL = 16
+    };
+
+    Pizza() = delete;
+    Pizza(PizzaType type, PizzaSize size);
+    ~Pizza() = default;
+
+ private:
+    const PizzaType _type;
+    const PizzaSize _size;
+};
+}  // namespace plazza
+
+#endif  // SRC_PLAZZA_PIZZA_HPP_

--- a/src/plazza/Pizza.hpp
+++ b/src/plazza/Pizza.hpp
@@ -7,8 +7,15 @@
 
 #ifndef SRC_PLAZZA_PIZZA_HPP_
 #define SRC_PLAZZA_PIZZA_HPP_
+#include <string>
+#include <unordered_set>
 
 namespace plazza {
+static const std::unordered_set<std::string> validPizzaTypes = {
+    "regina", "margarita", "americana", "fantasia"};
+static const std::unordered_set<std::string> validPizzaSizes = {
+    "S", "M", "L", "XL", "XXL"};
+
 class Pizza {
  public:
     enum PizzaType {

--- a/src/plazza/reception/Reception.cpp
+++ b/src/plazza/reception/Reception.cpp
@@ -1,0 +1,62 @@
+/*
+** EPITECH PROJECT, 2025
+** La-Pizza-Delamama
+** File description:
+** Reception
+*/
+
+#include "Reception.hpp"
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+plazza::Reception::Reception(
+    double cookingMultiplier, unsigned int cookNb, unsigned int restockTime)
+    : _cookingMultiplier(cookingMultiplier),
+      _cookNb(cookNb),
+      _restockTime(restockTime) {}
+
+static std::vector<std::string> split(
+    const std::string &str, const std::string &delimiter) {
+    std::vector<std::string> tokens;
+    size_t start = 0, end = 0;
+
+    end = str.find(delimiter, start);
+    while (end != std::string::npos) {
+        tokens.push_back(str.substr(start, end - start));
+        start = end + delimiter.length();
+        end = str.find(delimiter, start);
+    }
+    if (start < str.length())
+        tokens.push_back(str.substr(start));
+    return tokens;
+}
+
+bool plazza::Reception::processOrder(const std::string &order) {
+    std::vector<std::string> pizzaOrders = split(order, "; ");
+
+    for (auto pizza : pizzaOrders) {
+        // std::cout << "Pizza order:" << pizza << std::endl;
+        if (!validatePizza(pizza)) {
+            std::cout << "Invalid pizza order: " << pizza << std::endl;
+            return false;
+        }
+    }
+    return true;
+}
+
+bool plazza::Reception::validatePizza(const std::string &pizza) {
+    std::string validPizzas[] = {"regina", "margarita", "americana",
+        "fantasia"};  // Probably gonna be replaced by a global constant
+    std::vector<std::string> tokenizedPizza = split(pizza, " ");
+
+    // for (auto token : tokenizedPizza) {
+    //     std::cout << token << std::endl;
+    // }
+    if (tokenizedPizza.size() != 3) {
+        std::cout << "Missing info: " << pizza << std::endl;
+        return false;
+    }
+    return true;
+}

--- a/src/plazza/reception/Reception.cpp
+++ b/src/plazza/reception/Reception.cpp
@@ -9,7 +9,11 @@
 
 #include <iostream>
 #include <string>
+#include <unordered_set>
 #include <vector>
+
+#include "Utils.hpp"
+#include "plazza/Pizza.hpp"
 
 plazza::Reception::Reception(
     double cookingMultiplier, unsigned int cookNb, unsigned int restockTime)
@@ -17,45 +21,51 @@ plazza::Reception::Reception(
       _cookNb(cookNb),
       _restockTime(restockTime) {}
 
-static std::vector<std::string> split(
-    const std::string &str, const std::string &delimiter) {
-    std::vector<std::string> tokens;
-    size_t start = 0, end = 0;
-
-    end = str.find(delimiter, start);
-    while (end != std::string::npos) {
-        tokens.push_back(str.substr(start, end - start));
-        start = end + delimiter.length();
-        end = str.find(delimiter, start);
-    }
-    if (start < str.length())
-        tokens.push_back(str.substr(start));
-    return tokens;
-}
-
 bool plazza::Reception::processOrder(const std::string &order) {
-    std::vector<std::string> pizzaOrders = split(order, "; ");
+    std::vector<std::string> pizzaOrders = utils::split(order, "; ");
 
     for (auto pizza : pizzaOrders) {
-        // std::cout << "Pizza order:" << pizza << std::endl;
-        if (!validatePizza(pizza)) {
-            std::cout << "Invalid pizza order: " << pizza << std::endl;
+        if (pizza.empty()) {
+            std::cout << "Empty pizza order" << std::endl;
             return false;
         }
+        if (!validatePizza(pizza))
+            return false;
     }
     return true;
 }
 
 bool plazza::Reception::validatePizza(const std::string &pizza) {
-    std::string validPizzas[] = {"regina", "margarita", "americana",
-        "fantasia"};  // Probably gonna be replaced by a global constant
-    std::vector<std::string> tokenizedPizza = split(pizza, " ");
+    std::vector<std::string> tokenizedPizza = utils::split(pizza, " ");
 
-    // for (auto token : tokenizedPizza) {
-    //     std::cout << token << std::endl;
-    // }
     if (tokenizedPizza.size() != 3) {
-        std::cout << "Missing info: " << pizza << std::endl;
+        std::cout << (tokenizedPizza.size() < 3 ? "Too few" : "Too many")
+                  << " values: " << pizza << std::endl;
+        std::cout << "Expected format: <type> <size> <count>" << std::endl;
+        return false;
+    }
+    if (!utils::isValidPizzaType(tokenizedPizza[0])) {
+        std::cout << "Invalid pizza type: " << tokenizedPizza[0] << std::endl;
+        std::cout << "Valid types are: ";
+        for (const auto &type : plazza::validPizzaTypes)
+            std::cout << type << " ";
+        std::cout << std::endl;
+        return false;
+    }
+    if (!utils::isValidPizzaSize(tokenizedPizza[1])) {
+        std::cout << "Invalid pizza size: " << tokenizedPizza[1] << std::endl;
+        std::cout << "Valid sizes are: ";
+        for (const auto &size : plazza::validPizzaSizes)
+            std::cout << size << " ";
+        std::cout << std::endl;
+        return false;
+    }
+    if (!utils::isValidPizzaCount(tokenizedPizza[2])) {
+        std::cout << "Invalid pizza count: " << tokenizedPizza[2] << std::endl;
+        std::cout
+            << "Count should be in the format 'xN' where N is a positive "
+               "integer"
+            << std::endl;
         return false;
     }
     return true;

--- a/src/plazza/reception/Reception.hpp
+++ b/src/plazza/reception/Reception.hpp
@@ -1,0 +1,31 @@
+/*
+** EPITECH PROJECT, 2025
+** La-Pizza-Delamama
+** File description:
+** Reception
+*/
+
+#ifndef SRC_PLAZZA_RECEPTION_RECEPTION_HPP_
+#define SRC_PLAZZA_RECEPTION_RECEPTION_HPP_
+#include <string>
+
+namespace plazza {
+class Reception {
+ public:
+    Reception() = delete;
+    Reception(double cookingMultiplier, unsigned int cookNb,
+        unsigned int restockTime);
+    ~Reception() = default;
+    // Function to process an order, returns true if the order is valid
+    bool processOrder(const std::string &order);
+
+ protected:
+ private:
+    double _cookingMultiplier;
+    unsigned int _cookNb;
+    unsigned int _restockTime;
+    bool validatePizza(const std::string &pizza);
+};
+}  // namespace plazza
+
+#endif  // SRC_PLAZZA_RECEPTION_RECEPTION_HPP_


### PR DESCRIPTION
I emplemented a basic shell with commands:

- help
- exit
- ordering with <type> <size> <number>

With validating of orders, case insensitive. ReGiNa xL X4 will be valid.
Types of pizza and their sizes are hardcoded in `./src/plazza/Pizza.hpp`